### PR TITLE
Update path to official sass port

### DIFF
--- a/assets/sass/bootstrap.scss
+++ b/assets/sass/bootstrap.scss
@@ -2,51 +2,51 @@
 
 // Core variables and mixins
 @import "bootstrap-variables";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_mixins.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_mixins.scss";
 
 // Reset and dependencies
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_normalize.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_print.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_glyphicons.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_normalize.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_print.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_glyphicons.scss";
 
 // Core CSS
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_scaffolding.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_type.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_code.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_grid.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_tables.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_forms.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_buttons.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_scaffolding.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_type.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_code.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_grid.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_tables.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_forms.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_buttons.scss";
 
 // Components
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_component-animations.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_dropdowns.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_button-groups.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_input-groups.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_navs.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_navbar.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_breadcrumbs.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_pagination.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_pager.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_labels.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_badges.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_jumbotron.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_thumbnails.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_alerts.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_progress-bars.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_media.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_list-group.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_panels.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_responsive-embed.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_wells.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_close.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_component-animations.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_dropdowns.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_button-groups.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_input-groups.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_navs.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_navbar.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_breadcrumbs.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_pagination.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_pager.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_labels.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_badges.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_jumbotron.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_thumbnails.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_alerts.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_progress-bars.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_media.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_list-group.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_panels.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_responsive-embed.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_wells.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_close.scss";
 
 // Components w/ JavaScript
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_modals.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_tooltip.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_popovers.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_carousel.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_modals.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_tooltip.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_popovers.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_carousel.scss";
 
 // Utility classes
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_utilities.scss";
-@import "../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap/_responsive-utilities.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_utilities.scss";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/_responsive-utilities.scss";


### PR DESCRIPTION
The bower_components in the path wasn't considering .bowerrc path changes. Also it appears that vendor is no longer in the path for the bootstrap official sass port.
