### PR TITLE
Enabled HTTPS support

### DIFF
--- a/assets/sass/bootsketch.scss
+++ b/assets/sass/bootsketch.scss
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 
-@import url(http://fonts.googleapis.com/css?family=Cabin+Sketch:400,700);
+@import url(//fonts.googleapis.com/css?family=Cabin+Sketch:400,700);
 @font-face {
     font-family: 'Glyphicons Halflings';
     src: url('../fonts/glyphicons-halflings-regular.eot?v2');


### PR DESCRIPTION
Turned the Cabin Sketch import into a protocol agnostic URL (http://www.paulirish.com/2010/the-protocol-relative-url/) to enable HTTPS support.
